### PR TITLE
[fix] remove `export` from `environment` in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,10 @@ services:
     image: ghcr.io/leafduo/chatgpt-telegram-bot:latest
     restart: always
     environment:
-      - export OPENAI_API_KEY=<your_openai_api_key>
-      - export TELEGRAM_APITOKEN=<your_telegram_bot_token>
+      - OPENAI_API_KEY=<your_openai_api_key>
+      - TELEGRAM_APITOKEN=<your_telegram_bot_token>
       # optional, default is empty. Only allow these users to use the bot. Empty means allow all users.
-      - export ALLOWED_TELEGRAM_ID=<your_telegram_id>,<your_friend_telegram_id>
+      - ALLOWED_TELEGRAM_ID=<your_telegram_id>,<your_friend_telegram_id>
       # optional, default is 1.0. Higher temperature means more random responses.
       # See https://platform.openai.com/docs/api-reference/chat/create#chat/create-temperature
-      - export MODEL_TEMPERATURE=1.0
+      - MODEL_TEMPERATURE=1.0


### PR DESCRIPTION
Remove unnecessary `export` from `environment`, otherwise the container will keep restarting due to the failure. 